### PR TITLE
Make publish generic to allow sharing types

### DIFF
--- a/src/redis-pubsub.ts
+++ b/src/redis-pubsub.ts
@@ -60,7 +60,7 @@ export class RedisPubSub implements PubSubEngine {
     this.currentSubscriptionId = 0;
   }
 
-  public async publish(trigger: string, payload: any): Promise<void> {
+  public async publish<T>(trigger: string, payload: T): Promise<void> {
     await this.redisPublisher.publish(trigger, JSON.stringify(payload));
   }
 


### PR DESCRIPTION
Imagine you have this subscription resolver with a payload type:

```ts
Subscription: {
  [CREATE_USER_TOPIC]: {
    resolve: (payload: CreateUserPayload) => new User(payload.user),
    subscribe: () => pubsub.asyncIterator(CREATE_USER_TOPIC),
  },
},
```

And now you can share the type and protect the publish too:

```ts
pubsub.publish<CreateUserPayload>(CREATE_USER_TOPIC, createUserPayload),
```